### PR TITLE
warning fixes

### DIFF
--- a/Source/DirectShow/Controls/D3DRenderer.cs
+++ b/Source/DirectShow/Controls/D3DRenderer.cs
@@ -390,7 +390,7 @@ namespace WPFMediaKit.DirectShow.Controls
                 D3DImage.Unlock();
                 SetNaturalWidthHeight();
             }
-            catch (Exception ex)
+            catch
             { }
 
             /* Clear our flag, so this won't be ran again

--- a/Source/DirectShow/MediaPlayers/DirectShowUtil.cs
+++ b/Source/DirectShow/MediaPlayers/DirectShowUtil.cs
@@ -39,7 +39,7 @@ namespace WPFMediaKit.DirectShow.MediaPlayers
                 }
                 return NewFilter;
             }
-            catch (Exception ex)
+            catch //(Exception ex)
             {
                 //Log.Error("Failed filter: {0} not found {0}", strFilterName, ex.Message);
                 return null;

--- a/Source/DirectShow/MediaPlayers/MediaSeekingPlayer.cs
+++ b/Source/DirectShow/MediaPlayers/MediaSeekingPlayer.cs
@@ -28,7 +28,7 @@ namespace WPFMediaKit.DirectShow.MediaPlayers
         /// <summary>
         /// Sets the rate at which the media plays back
         /// </summary>
-        public double SpeedRatio
+        public virtual double SpeedRatio
         {
             get
             {

--- a/Source/DirectShow/MediaPlayers/Vmr9Allocator.cs
+++ b/Source/DirectShow/MediaPlayers/Vmr9Allocator.cs
@@ -11,7 +11,7 @@ namespace WPFMediaKit.DirectShow.MediaPlayers
     /// The Vmr9Allocator is a custom allocator for the VideoMixingRenderer9
     /// </summary>
     [ComVisible(true)]
-    public class Vmr9Allocator : IVMRSurfaceAllocator9, IVMRImagePresenter9, ICustomAllocator
+    public class Vmr9Allocator: IVMRSurfaceAllocator9, IVMRImagePresenter9, ICustomAllocator
     {
         /// <summary>
         /// Base constant for FAIL error codes
@@ -27,7 +27,7 @@ namespace WPFMediaKit.DirectShow.MediaPlayers
         /// Lock for shared resources
         /// </summary>
         private static object m_staticLock = new object();
-        
+
         /// <summary>
         /// Direct3D functions
         /// </summary>
@@ -57,6 +57,8 @@ namespace WPFMediaKit.DirectShow.MediaPlayers
         /// Part of the "Dispose" pattern
         /// </summary>
         private bool m_disposed;
+
+        public bool IsDisposed { get { return m_disposed; } }
 
         /// <summary>
         /// Applications use this interface to set a custom allocator-presenter 

--- a/Source/Threading/WorkDispatcher.cs
+++ b/Source/Threading/WorkDispatcher.cs
@@ -212,7 +212,7 @@ namespace WPFMediaKit.Threading
                     if (method != null)
                         method.DynamicInvoke(null);
                 }
-                catch (Exception ex)
+                catch
                 {
                     throw;
                 }


### PR DESCRIPTION
Fixed a few warnings. `Vmr9Allocator .m_disposed` has been not used, so it could be removed (instead of public `IsDisposed`) as well.

I have added a requirement to make `MediaSeekingPlayer.SpeedRatio` virtual, but I can separate it to another PR if you wish to.
