### PR TITLE
Fix MediaUriPlayer Uri to string conversion

### DIFF
--- a/Source/DirectShow/MediaPlayers/MediaUriPlayer.cs
+++ b/Source/DirectShow/MediaPlayers/MediaUriPlayer.cs
@@ -93,6 +93,21 @@ namespace WPFMediaKit.DirectShow.MediaPlayers
         }
 
         /// <summary>
+        /// Return Source as a string path or uri.
+        /// </summary>
+        private string FileSource
+        {
+            get
+            {
+                if (m_sourceUri == null)
+                    return null;
+                if (m_sourceUri.IsFile)
+                    return m_sourceUri.LocalPath;
+                return m_sourceUri.ToString();
+            }
+        }
+
+        /// <summary>
         /// The renderer type to use when
         /// rendering video
         /// </summary>
@@ -255,10 +270,7 @@ namespace WPFMediaKit.DirectShow.MediaPlayers
             /* Make sure we clean up any remaining mess */
             FreeResources();
 
-            if (m_sourceUri == null)
-                return;
-
-            string fileSource = m_sourceUri.OriginalString;
+            string fileSource = FileSource;
 
             if (string.IsNullOrEmpty(fileSource))
                 return;
@@ -453,10 +465,7 @@ namespace WPFMediaKit.DirectShow.MediaPlayers
             /* Make sure we clean up any remaining mess */
             FreeResources();
 
-            if (m_sourceUri == null)
-                return false;
-
-            string fileSource = m_sourceUri.OriginalString;
+            string fileSource = FileSource;
 
             if (string.IsNullOrEmpty(fileSource))
                 return false;


### PR DESCRIPTION
When a Source Uri is constructed from the local path with a space like:
1. `new Uri("file:///C:/video space.mp4");`
2. `new Uri("file:///C:/video%20space.mp4");`

Then the `MediaUriPlayer.OpenSource()` fails. (In case of 1. the `oldOpenSource()` works, but it fails for 2. as well.) I have added a private `FileSource` to convert local file to the absolute file always. 
